### PR TITLE
make point size depend on size of field of view

### DIFF
--- a/napari_tools_menu/__init__.py
+++ b/napari_tools_menu/__init__.py
@@ -107,7 +107,7 @@ def make_gui(func, viewer, *args, **kwargs):
                 target_layer.name = new_name
                 # layer.translate = translate
                 if sig.return_annotation in [PointsData, "napari.types.PointsData"]:
-                    target_layer.size = 0.5
+                    target_layer.size = np.asarray(viewer.dims.range).max() * 0.01
 
             except StopIteration:
                 # otherwise create a new one

--- a/napari_tools_menu/__init__.py
+++ b/napari_tools_menu/__init__.py
@@ -119,7 +119,7 @@ def make_gui(func, viewer, *args, **kwargs):
                         target_layer = viewer.add_labels(data, name=new_name)
                     elif sig.return_annotation in [PointsData, "napari.types.PointsData"]:
                         target_layer = viewer.add_points(data, name=new_name)
-                        target_layer.size = 0.5
+                        target_layer.size = np.asarray(viewer.dims.range).max() * 0.01
                     elif sig.return_annotation in [SurfaceData, "napari.types.SurfaceData"]:
                         target_layer = viewer.add_surface(data, name=new_name)
 


### PR DESCRIPTION
Hi Johannes @jo-mueller,

I'm thinking of modifying the default-pointsize of all operations that create `PointsData` and sit in the tools menu. I was considering to make the point size equal to 1% of the field of view in the viewer. In case of the droplet used in the stress-project, this would look like this:

![image](https://user-images.githubusercontent.com/12660498/174326704-41112de4-3736-4ce1-ae45-04dafa74997c.png)

What's your opinion, shall the spots be bigger per default? Also, would you mind checking if thes does work with the plugins and data you are working on?

Thanks,
Robert