### PR TITLE
Delayed imports and dummy objects

### DIFF
--- a/napari_tools_menu/__init__.py
+++ b/napari_tools_menu/__init__.py
@@ -1,12 +1,22 @@
 import warnings
+
 try:
     import napari._qt
     from qtpy.QtWidgets import QMenu
-except:
-    warnings.warn("importing QT failed")
+except ModuleNotFoundError as e:
+    warnings.warn("Importing QT failed; now introducing dummy definitions of QMenu class and register_function decorator.")
+
+    # Define dummy class QMenu, to be used in ToolsMenu below
     class QMenu:
         pass
-    pass
+
+    # Define dummy register_action decorator, so that it can be imported and
+    # used in packages that do not depend on QT
+    @curry
+    def register_action(func: Callable, menu:str, *args, **kwargs) -> Callable:
+        return func
+
+
 import numpy as np
 
 from toolz import curry

--- a/napari_tools_menu/__init__.py
+++ b/napari_tools_menu/__init__.py
@@ -1,5 +1,8 @@
 import warnings
 
+from toolz import curry
+from typing import Callable
+
 try:
     import napari._qt
     from qtpy.QtWidgets import QMenu
@@ -19,8 +22,6 @@ except ModuleNotFoundError as e:
 
 import numpy as np
 
-from toolz import curry
-from typing import Callable
 import inspect
 from functools import wraps
 

--- a/napari_tools_menu/__init__.py
+++ b/napari_tools_menu/__init__.py
@@ -1,5 +1,4 @@
 import warnings
-import napari
 try:
     import napari._qt
     from qtpy.QtWidgets import QMenu
@@ -21,6 +20,7 @@ class ToolsMenu(QMenu):
 
     def __init__(self, window: 'Window', viewer):
         from napari.utils.translations import trans
+        import napari
 
         super().__init__(trans._('&Tools'), window._qt_window)
         self.viewer = viewer

--- a/napari_tools_menu/__init__.py
+++ b/napari_tools_menu/__init__.py
@@ -5,12 +5,13 @@ try:
     from qtpy.QtWidgets import QMenu
 except:
     warnings.warn("importing QT failed")
+    class QMenu:
+        pass
     pass
 import numpy as np
 
 from toolz import curry
 from typing import Callable
-from magicgui import magicgui
 import inspect
 from functools import wraps
 
@@ -81,7 +82,9 @@ def make_gui(func, viewer, *args, **kwargs):
     gui = None
 
     from napari.types import ImageData, LabelsData, PointsData, SurfaceData
+    from magicgui import magicgui
     import inspect
+
     sig = inspect.signature(func)
 
     @wraps(func)


### PR DESCRIPTION
After this PR, we can have
```python
from napari_tools_menu import register_function
```
in another package (e.g. napari-skimage-regionprops), and the import will fail gracefully (that is, it will only raise a warning) when receiving a `ModuleNotFoundError` from
```python
    import napari._qt
    from qtpy.QtWidgets import QMenu
```

This goes in the direction of making other packages (like napari-skimage-regionprops) work also in the absence of QT/napari dependencies (see https://github.com/haesleinhuepf/napari-skimage-regionprops/issues/36).