### PR TITLE
Capture any Exception upon importing QT, instead of just `ModuleNotFoundError`

### DIFF
--- a/napari_tools_menu/__init__.py
+++ b/napari_tools_menu/__init__.py
@@ -6,7 +6,7 @@ from typing import Callable
 try:
     import napari._qt
     from qtpy.QtWidgets import QMenu
-except ModuleNotFoundError as e:
+except Exception as e:
     warnings.warn("Importing QT failed; now introducing dummy definitions of QMenu class and register_function decorator.")
 
     # Define dummy class QMenu, to be used in ToolsMenu below


### PR DESCRIPTION
As described in #11, the way import errors are handled in `napari._qt` is inconsistent with qtpy 0.2.3. This is not a napari-tools-menu issue, but it's probably to be handled on the qtpy side.

Fixing that issue in qtpy, however, is not enough to make napari-tools-menu=0.1.18 work with qtpy=0.2.3. The reason is that napari-tools-menu currently only catches `ModuleNotFoundError`s, but qtpy>=0.2.3 will raise a `QtBindingsNotFoundError`.

### Steps to reproduce
```
pip install napari-tools-menu==0.1.18
pip install qtpy==0.2.3
python -c "import napari_tools_menu"
```

### Proposed solution in this PR
napari-tools-menu could be agnostic about the exceptions raised by other packages (napari._qt and qtpy) upon import , and catch any Exception.